### PR TITLE
Moved the examples directory to the root

### DIFF
--- a/examples/client.ts
+++ b/examples/client.ts
@@ -1,4 +1,4 @@
-import RxAmqpLib from '../rx-amqplib/RxAmqpLib';
+import RxAmqpLib from '../src/rx-amqplib/RxAmqpLib';
 import * as R from 'ramda';
 
 let config = {

--- a/examples/server.ts
+++ b/examples/server.ts
@@ -1,4 +1,4 @@
-import RxAmqpLib from '../rx-amqplib/RxAmqpLib';
+import RxAmqpLib from '../src/rx-amqplib/RxAmqpLib';
 import {Message} from 'amqplib/properties';
 import * as R from 'ramda';
 


### PR DESCRIPTION
## Scope

Moves the example directory to the root of the project. Makes them more visible and shouldn't be part of the source.
