### PR TITLE
onCompleted when connection closed

### DIFF
--- a/dist/RxAmqpLib.js
+++ b/dist/RxAmqpLib.js
@@ -1,4 +1,3 @@
-"use strict";
 var Rx = require('rx');
 var AmqpLib = require('amqplib');
 var RxConnection_1 = require('./RxConnection');
@@ -38,6 +37,6 @@ var RxAmqpLib = (function () {
         });
     };
     return RxAmqpLib;
-}());
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = RxAmqpLib;


### PR DESCRIPTION
This change makes the Rx.Observable from `RxAmqpLib.newConnect()` emit `onCompleted` when the underlying AmqpLib connection is closed. As well, if the consumer disposes of the subscription it will close the connection. 

Currently, as a result of `fromPromise` the `onNext` emits `RxConnection` immediately followed by the `onCompleted`. This semantic change will allow someone to reconnect to the server when the connection is closed:

``` javascript
RxAmqpLib.newConnection('http://localhost')
  .concat(Rx.Observable.throw())
  .retry()
  .flatMap(connection => connection.createChannel())
// .. etc
  .subscribe(console.log)
```
